### PR TITLE
feat: allow inputting feel builtins & variables directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,19 @@ import { lintExpression } from "@bpmn-io/feel-lint"
 lintExpression('foo = bar');
 ```
 
-You may pass custom language configuration to the editor:
+You may pass custom language configuration to the editor. Checkout [@camunda/feel-builtins](https://github.com/camunda/feel-builtins) for a reference of built-in functions.
 
 ```javascript
+import { camundaBuiltins } from '@camunda/feel-builtins';
+
 lintExpression('> 10, "yes", mike\'s name', {
   dialect: 'unaryTests',
-  context: {
-    "mike's name": "Mike the might"
-  }
+  builtins: camundaBuiltins,
+  variables:  [
+    {
+       name: `mike's name`
+    }
+  ]
 });
 ```
 

--- a/lib/text/index.js
+++ b/lib/text/index.js
@@ -1,5 +1,6 @@
 import { parser, trackVariables } from 'lezer-feel';
 import lintAll from '../shared/index.js';
+import { createContext } from './util.js';
 
 /**
  * Create an array of syntax errors for the given expression.
@@ -7,17 +8,21 @@ import lintAll from '../shared/index.js';
  * @param {String} expression
  * @param { {
  *   dialect?: 'expression' | 'unaryTests',
- *   context?: Record<string, any>,
- *   parserDialect?: string
+ *   parserDialect?: string,
+ *   builtins?: import("./util.js").Variable[],
+ *   variables?: import("./util.js").Variable[],
  * } } [lintOptions]
  *
- * @returns {LintMessage[]} array of syntax errors
+ * @returns {import("../shared").LintMessage[]} array of syntax errors
  */
 export function lintExpression(expression, {
   dialect = 'expression',
   parserDialect,
-  context = {}
+  builtins = [],
+  variables = [],
 } = {}) {
+
+  const context = createContext([ ...builtins, ...variables ]);
 
   const syntaxTree = parser.configure({
     top: dialect === 'unaryTests' ? 'UnaryTests' : 'Expression',

--- a/lib/text/util.js
+++ b/lib/text/util.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {object} Variable
+ * @property {string} name name or key of the variable
+ * @property {string} [info] longer description of the variable content
+ * @property {string} [detail] short information about the variable, e.g. type
+ * @property {boolean} [isList] whether the variable is a list
+ * @property {Array<Variable>} [schema] array of child variables if the variable is a context or list
+ * @property {Array<{name: string, type: string}>} [params] function parameters
+ */
+
+/**
+ * @param { Variable[] } variables
+ *
+ * @return {Record<string, any>}
+ */
+export function createContext(variables) {
+  return variables.slice().reverse().reduce((context, variable) => {
+    context[variable.name] = () => {};
+
+    return context;
+  }, {});
+}

--- a/test/spec/textLinter.spec.js
+++ b/test/spec/textLinter.spec.js
@@ -47,16 +47,16 @@ describe('lint - Text', function() {
   });
 
 
-  it('should accept valid expression with contextual value', function() {
+  it('should accept valid expression with builtins', function() {
 
     // given
     const expression = 'get or else(10, 100)';
 
     // when
     const results = lintExpression(expression, {
-      context: {
-        'get or else': (value, _default) => typeof value === 'undefined' ? _default : value
-      }
+      builtins: [
+        { name: 'get or else', params: [ { name: 'value' }, { name: 'default' } ] }
+      ]
     });
 
     // then


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/3983

### Proposed Changes

> [!CAUTION]
> BREAKING CHANGE: `context` is replaced with `builtins` & `variables`

Allow inputting feel builtins & variables directly (ie not as context). 



Checkout https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/206 to see how it could be used

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
