### PR TITLE
feat: lint FEEL built-ins against target engine version

### DIFF
--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -6,20 +6,14 @@ import lintAll from '../shared/index.js';
  *
  * @param { {
  *   builtins?: import('../text/util.js').Variable[],
- *   reservedNameBuiltins?: import('../text/util.js').Variable[],
  *   engines?: Record<string, string>,
- *   dialect?: 'expression' | 'unaryTests',
- *   parserDialect?: string,
  * } } [options] enables version-compatibility linting when `engines` is set
  *
  * @returns {import('@codemirror/lint').LintSource} CodeMirror linting source
  */
 export const cmFeelLinter = ({
   builtins = [],
-  reservedNameBuiltins = [],
-  engines,
-  dialect,
-  parserDialect
+  engines
 } = {}) => editorView => {
 
   // don't lint if the Editor is empty
@@ -32,10 +26,7 @@ export const cmFeelLinter = ({
   const messages = lintAll({
     syntaxTree: tree,
     expression: editorView.state.doc.toString(),
-    dialect,
-    parserDialect,
     builtins,
-    reservedNameBuiltins,
     engines,
     readContent: (from, to) => editorView.state.sliceDoc(from, to),
     updateContent: (from, to, content) => editorView.dispatch({

--- a/lib/editor/index.js
+++ b/lib/editor/index.js
@@ -4,9 +4,23 @@ import lintAll from '../shared/index.js';
 /**
  * CodeMirror extension that provides linting for FEEL expressions.
  *
+ * @param { {
+ *   builtins?: import('../text/util.js').Variable[],
+ *   reservedNameBuiltins?: import('../text/util.js').Variable[],
+ *   engines?: Record<string, string>,
+ *   dialect?: 'expression' | 'unaryTests',
+ *   parserDialect?: string,
+ * } } [options] enables version-compatibility linting when `engines` is set
+ *
  * @returns {import('@codemirror/lint').LintSource} CodeMirror linting source
  */
-export const cmFeelLinter = () => editorView => {
+export const cmFeelLinter = ({
+  builtins = [],
+  reservedNameBuiltins = [],
+  engines,
+  dialect,
+  parserDialect
+} = {}) => editorView => {
 
   // don't lint if the Editor is empty
   if (editorView.state.doc.length === 0) {
@@ -17,6 +31,12 @@ export const cmFeelLinter = () => editorView => {
 
   const messages = lintAll({
     syntaxTree: tree,
+    expression: editorView.state.doc.toString(),
+    dialect,
+    parserDialect,
+    builtins,
+    reservedNameBuiltins,
+    engines,
     readContent: (from, to) => editorView.state.sliceDoc(from, to),
     updateContent: (from, to, content) => editorView.dispatch({
       changes: { from, to, insert: content }

--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -1,9 +1,11 @@
 import lintSyntax from './syntax.js';
 import { lintRules } from './rules.js';
+import lintCompatibility from '../../rules/compatibility.js';
 
 /**
  * @typedef {import('@lezer/common').Tree} Tree
  * @typedef {import('@codemirror/lint').Diagnostic} LintMessage
+ * @typedef {import('../text/util.js').Variable} Variable
  */
 
 /**
@@ -11,6 +13,12 @@ import { lintRules } from './rules.js';
  * @property {Tree} syntaxTree
  * @property {(from: number, to: number) => string} readContent
  * @property {(from: number, to: number, content: string) => void} updateContent
+ * @property {string} [expression] full expression text (required for compatibility linting)
+ * @property {Record<string, string>} [engines] provided engine versions, e.g. `{ camunda: '8.6' }`
+ * @property {Variable[]} [builtins]
+ * @property {Variable[]} [reservedNameBuiltins]
+ * @property {'expression' | 'unaryTests'} [dialect]
+ * @property {string} [parserDialect]
  */
 
 /**
@@ -23,7 +31,8 @@ export default function lintAll(context) {
 
   const lintMessages = [
     ...lintSyntax(context.syntaxTree),
-    ...lintRules(context)
+    ...lintRules(context),
+    ...lintCompatibility(context)
   ];
 
   return lintMessages;

--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -13,12 +13,9 @@ import lintCompatibility from '../../rules/compatibility.js';
  * @property {Tree} syntaxTree
  * @property {(from: number, to: number) => string} readContent
  * @property {(from: number, to: number, content: string) => void} updateContent
- * @property {string} [expression] full expression text (required for compatibility linting)
+ * @property {string} [expression] source the tree was parsed from (for compatibility linting)
  * @property {Record<string, string>} [engines] provided engine versions, e.g. `{ camunda: '8.6' }`
  * @property {Variable[]} [builtins]
- * @property {Variable[]} [reservedNameBuiltins]
- * @property {'expression' | 'unaryTests'} [dialect]
- * @property {string} [parserDialect]
  */
 
 /**

--- a/lib/text/index.js
+++ b/lib/text/index.js
@@ -11,6 +11,8 @@ import { createContext } from './util.js';
  *   parserDialect?: string,
  *   builtins?: import("./util.js").Variable[],
  *   variables?: import("./util.js").Variable[],
+ *   reservedNameBuiltins?: import("./util.js").Variable[],
+ *   engines?: Record<string, string>,
  * } } [lintOptions]
  *
  * @returns {import("../shared").LintMessage[]} array of syntax errors
@@ -20,6 +22,8 @@ export function lintExpression(expression, {
   parserDialect,
   builtins = [],
   variables = [],
+  reservedNameBuiltins = [],
+  engines,
 } = {}) {
 
   const context = createContext([ ...builtins, ...variables ]);
@@ -32,6 +36,12 @@ export function lintExpression(expression, {
 
   const lintMessages = lintAll({
     syntaxTree,
+    expression,
+    dialect,
+    parserDialect,
+    builtins,
+    reservedNameBuiltins,
+    engines,
     readContent: (from, to) => expression.slice(from, to),
     updateContent: (from, to, content) => {
 

--- a/lib/text/index.js
+++ b/lib/text/index.js
@@ -15,7 +15,7 @@ import { createContext } from './util.js';
  *   engines?: Record<string, string>,
  * } } [lintOptions]
  *
- * @returns {import("../shared").LintMessage[]} array of syntax errors
+ * @returns {import("../shared").LintMessage[]} array of lint messages
  */
 export function lintExpression(expression, {
   dialect = 'expression',

--- a/lib/text/index.js
+++ b/lib/text/index.js
@@ -11,7 +11,6 @@ import { createContext } from './util.js';
  *   parserDialect?: string,
  *   builtins?: import("./util.js").Variable[],
  *   variables?: import("./util.js").Variable[],
- *   reservedNameBuiltins?: import("./util.js").Variable[],
  *   engines?: Record<string, string>,
  * } } [lintOptions]
  *
@@ -22,7 +21,6 @@ export function lintExpression(expression, {
   parserDialect,
   builtins = [],
   variables = [],
-  reservedNameBuiltins = [],
   engines,
 } = {}) {
 
@@ -37,10 +35,7 @@ export function lintExpression(expression, {
   const lintMessages = lintAll({
     syntaxTree,
     expression,
-    dialect,
-    parserDialect,
     builtins,
-    reservedNameBuiltins,
     engines,
     readContent: (from, to) => expression.slice(from, to),
     updateContent: (from, to, content) => {

--- a/lib/text/util.js
+++ b/lib/text/util.js
@@ -6,6 +6,7 @@
  * @property {boolean} [isList] whether the variable is a list
  * @property {Array<Variable>} [schema] array of child variables if the variable is a context or list
  * @property {Array<{name: string, type: string}>} [params] function parameters
+ * @property {Record<string, string>} [engines] engine version requirements, e.g. `{ camunda: '>=8.9' }`
  */
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/feel-analyzer": "^0.4.0",
+        "@bpmn-io/feel-analyzer": "^0.5.0",
         "@bpmn-io/lezer-feel": "^3.0.0",
         "@bpmn-io/semver-compat": "^0.1.0",
         "@codemirror/language": "^6.12.1"
@@ -521,29 +521,16 @@
       }
     },
     "node_modules/@bpmn-io/feel-analyzer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-analyzer/-/feel-analyzer-0.4.0.tgz",
-      "integrity": "sha512-L0NpjcLhUI7L7TfRYpWv8tNGVciQQGJQurys1mSk4bQsdxnOcAQqiHGmiaV0ZHclVgVy5wd96qImb1hL497nAA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-analyzer/-/feel-analyzer-0.5.0.tgz",
+      "integrity": "sha512-g1H9MMkVH94fl0Hz2MiZ+AU2hnVTL+qsz8MvXx9xz+lBgBSp3tY342Vrxrzt36H8QqE4fn9noJc1emNA9BE3Dg==",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/lezer-feel": "^2.1.0"
+        "@bpmn-io/lezer-feel": "^3.0.1",
+        "@lezer/common": "^1.5.2"
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/@bpmn-io/feel-analyzer/node_modules/@bpmn-io/lezer-feel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.5.0.tgz",
-      "integrity": "sha512-09JlwNYeD5YYeFrl0dIFfgQKEL+NNiTyUwEtdcPhfftz1mYa7z+ylOPCv/8Z0GqG7X81uyMFvRZDFCRBFTiUPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/highlight": "^1.2.3",
-        "@lezer/lr": "^1.4.10",
-        "min-dash": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.12.0"
       }
     },
     "node_modules/@bpmn-io/lang-feel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
+        "@bpmn-io/feel-analyzer": "^0.4.0",
         "@bpmn-io/lezer-feel": "^3.0.0",
+        "@bpmn-io/semver-compat": "^0.1.0",
         "@codemirror/language": "^6.12.1"
       },
       "devDependencies": {
@@ -518,6 +520,32 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bpmn-io/feel-analyzer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-analyzer/-/feel-analyzer-0.4.0.tgz",
+      "integrity": "sha512-L0NpjcLhUI7L7TfRYpWv8tNGVciQQGJQurys1mSk4bQsdxnOcAQqiHGmiaV0ZHclVgVy5wd96qImb1hL497nAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^2.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@bpmn-io/feel-analyzer/node_modules/@bpmn-io/lezer-feel": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.5.0.tgz",
+      "integrity": "sha512-09JlwNYeD5YYeFrl0dIFfgQKEL+NNiTyUwEtdcPhfftz1mYa7z+ylOPCv/8Z0GqG7X81uyMFvRZDFCRBFTiUPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.10",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
     "node_modules/@bpmn-io/lang-feel": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-4.0.0.tgz",
@@ -544,6 +572,27 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/semver-compat": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/semver-compat/-/semver-compat-0.1.0.tgz",
+      "integrity": "sha512-hIcW42Ku92MUioL6aknDbRoW1jK8ZEqIe8qZZ+d3cjitDO+PMEFFXj/sezJYIHMe8elu4CBz9qpjkV8WIVG9qw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.2"
+      }
+    },
+    "node_modules/@bpmn-io/semver-compat/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@codemirror/autocomplete": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "webpack": "^5.105.0"
   },
   "dependencies": {
-    "@bpmn-io/feel-analyzer": "^0.4.0",
+    "@bpmn-io/feel-analyzer": "^0.5.0",
     "@bpmn-io/lezer-feel": "^3.0.0",
     "@bpmn-io/semver-compat": "^0.1.0",
     "@codemirror/language": "^6.12.1"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
     "webpack": "^5.105.0"
   },
   "dependencies": {
+    "@bpmn-io/feel-analyzer": "^0.4.0",
     "@bpmn-io/lezer-feel": "^3.0.0",
+    "@bpmn-io/semver-compat": "^0.1.0",
     "@codemirror/language": "^6.12.1"
   }
 }

--- a/rules/compatibility.js
+++ b/rules/compatibility.js
@@ -2,16 +2,15 @@ import { FeelAnalyzer } from '@bpmn-io/feel-analyzer';
 import { isCompatible } from '@bpmn-io/semver-compat';
 
 /**
+ * @typedef {import('@lezer/common').Tree} Tree
  * @typedef {import('../lib/text/util.js').Variable} Variable
  * @typedef {import('../lib/shared/index.js').LintMessage} LintMessage
  *
  * @typedef {object} CompatibilityContext
- * @property {string} expression the full expression text
+ * @property {Tree} syntaxTree the already-parsed syntax tree
+ * @property {string} expression the source the tree was parsed from
  * @property {Record<string, string>} [engines] provided engine versions, e.g. `{ camunda: '8.6' }`
  * @property {Variable[]} [builtins] built-ins, carrying `engines` requirements
- * @property {Variable[]} [reservedNameBuiltins] built-ins using reserved names (for parsing)
- * @property {'expression' | 'unaryTests'} [dialect]
- * @property {string} [parserDialect]
  */
 
 const RULE_NAME = 'compatibility';
@@ -20,7 +19,9 @@ const RULE_NAME = 'compatibility';
  * Reports calls to built-in functions that are not available in the provided
  * engine version(s).
  *
- * No-op unless `engines` is provided and built-ins carry `engines` metadata.
+ * Reuses the already-parsed `syntaxTree` (via feel-analyzer) instead of
+ * re-parsing. No-op unless `engines` is provided and built-ins carry `engines`
+ * metadata.
  *
  * @param {CompatibilityContext} context
  *
@@ -28,12 +29,10 @@ const RULE_NAME = 'compatibility';
  */
 export default function lintCompatibility(context = {}) {
   const {
+    syntaxTree,
     expression,
     engines,
-    builtins = [],
-    reservedNameBuiltins = [],
-    dialect,
-    parserDialect
+    builtins = []
   } = context;
 
   if (!engines || !Object.keys(engines).length || !builtins.length) {
@@ -46,14 +45,9 @@ export default function lintCompatibility(context = {}) {
     return [];
   }
 
-  const analyzer = new FeelAnalyzer({
-    dialect,
-    parserDialect,
-    builtins,
-    reservedNameBuiltins
-  });
+  const analyzer = new FeelAnalyzer({ builtins });
 
-  const { valid, functions = [] } = analyzer.analyzeExpression(expression);
+  const { valid, functions = [] } = analyzer.analyzeTree(syntaxTree, expression);
 
   // syntax errors are reported separately; don't double-report on broken input
   if (!valid) {

--- a/rules/compatibility.js
+++ b/rules/compatibility.js
@@ -1,0 +1,108 @@
+import { FeelAnalyzer } from '@bpmn-io/feel-analyzer';
+import { isCompatible } from '@bpmn-io/semver-compat';
+
+/**
+ * @typedef {import('../lib/text/util.js').Variable} Variable
+ * @typedef {import('../lib/shared/index.js').LintMessage} LintMessage
+ *
+ * @typedef {object} CompatibilityContext
+ * @property {string} expression the full expression text
+ * @property {Record<string, string>} [engines] provided engine versions, e.g. `{ camunda: '8.6' }`
+ * @property {Variable[]} [builtins] built-ins, carrying `engines` requirements
+ * @property {Variable[]} [reservedNameBuiltins] built-ins using reserved names (for parsing)
+ * @property {'expression' | 'unaryTests'} [dialect]
+ * @property {string} [parserDialect]
+ */
+
+const RULE_NAME = 'compatibility';
+
+/**
+ * Reports calls to built-in functions that are not available in the provided
+ * engine version(s).
+ *
+ * No-op unless `engines` is provided and built-ins carry `engines` metadata.
+ *
+ * @param {CompatibilityContext} context
+ *
+ * @returns {LintMessage[]}
+ */
+export default function lintCompatibility(context = {}) {
+  const {
+    expression,
+    engines,
+    builtins = [],
+    reservedNameBuiltins = [],
+    dialect,
+    parserDialect
+  } = context;
+
+  if (!engines || !Object.keys(engines).length || !builtins.length) {
+    return [];
+  }
+
+  const unavailable = getUnavailableBuiltins(builtins, engines);
+
+  if (!unavailable.size) {
+    return [];
+  }
+
+  const analyzer = new FeelAnalyzer({
+    dialect,
+    parserDialect,
+    builtins,
+    reservedNameBuiltins
+  });
+
+  const { valid, functions = [] } = analyzer.analyzeExpression(expression);
+
+  // syntax errors are reported separately; don't double-report on broken input
+  if (!valid) {
+    return [];
+  }
+
+  return functions.reduce((messages, fn) => {
+    if (fn.type !== 'builtin') {
+      return messages;
+    }
+
+    const builtin = unavailable.get(fn.name);
+
+    if (!builtin) {
+      return messages;
+    }
+
+    messages.push({
+      from: fn.from,
+      to: fn.to,
+      severity: 'warning',
+      type: RULE_NAME,
+      message: `Function '${ fn.name }' requires ${ formatEngines(builtin.engines) }`
+    });
+
+    return messages;
+  }, []);
+}
+
+// helpers //////////
+
+function getUnavailableBuiltins(builtins, engines) {
+  const unavailable = new Map();
+
+  for (const builtin of builtins) {
+    if (builtin.engines && !isCompatible(builtin.engines, engines)) {
+      unavailable.set(builtin.name, builtin);
+    }
+  }
+
+  return unavailable;
+}
+
+function formatEngines(engines) {
+  return Object.entries(engines)
+    .map(([ name, range ]) => `${ capitalize(name) } ${ range }`)
+    .join(', ');
+}
+
+function capitalize(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}

--- a/test/spec/editorLinter.spec.js
+++ b/test/spec/editorLinter.spec.js
@@ -119,6 +119,57 @@ describe('lint - Editor', function() {
     expect(results[0].message).to.eql('Unrecognized token in <Expression>');
   });
 
+
+  describe('compatibility', function() {
+
+    const builtins = [ { name: 'from json', engines: { camunda: '>=8.9' } } ];
+
+
+    it('should warn on version-incompatible builtin', function() {
+
+      // given
+      const view = createFeelViewer('from json("x")', { dialect: 'camunda' });
+      const lint = cmFeelLinter({ parserDialect: 'camunda', builtins, engines: { camunda: '8.6' } });
+
+      // when
+      const results = lint(view);
+
+      // then
+      expect(results).to.have.length(1);
+      expect(results[0].severity).to.eql('warning');
+      expect(results[0].source).to.eql('compatibility');
+      expect(results[0].message).to.eql('Function \'from json\' requires Camunda >=8.9');
+    });
+
+
+    it('should not warn when the version satisfies', function() {
+
+      // given
+      const view = createFeelViewer('from json("x")', { dialect: 'camunda' });
+      const lint = cmFeelLinter({ parserDialect: 'camunda', builtins, engines: { camunda: '8.9' } });
+
+      // when
+      const results = lint(view);
+
+      // then
+      expect(results).to.have.length(0);
+    });
+
+
+    it('should not warn without options', function() {
+
+      // given
+      const view = createFeelViewer('from json("x")', { dialect: 'camunda' });
+      const lint = cmFeelLinter();
+
+      // when
+      const results = lint(view);
+
+      // then
+      expect(results).to.have.length(0);
+    });
+  });
+
 });
 
 // helpers //////////

--- a/test/spec/editorLinter.spec.js
+++ b/test/spec/editorLinter.spec.js
@@ -129,7 +129,7 @@ describe('lint - Editor', function() {
 
       // given
       const view = createFeelViewer('from json("x")', { dialect: 'camunda' });
-      const lint = cmFeelLinter({ parserDialect: 'camunda', builtins, engines: { camunda: '8.6' } });
+      const lint = cmFeelLinter({ builtins, engines: { camunda: '8.6' } });
 
       // when
       const results = lint(view);
@@ -146,7 +146,7 @@ describe('lint - Editor', function() {
 
       // given
       const view = createFeelViewer('from json("x")', { dialect: 'camunda' });
-      const lint = cmFeelLinter({ parserDialect: 'camunda', builtins, engines: { camunda: '8.9' } });
+      const lint = cmFeelLinter({ builtins, engines: { camunda: '8.9' } });
 
       // when
       const results = lint(view);

--- a/test/spec/rules/compatibility.spec.js
+++ b/test/spec/rules/compatibility.spec.js
@@ -1,0 +1,205 @@
+import lintCompatibility from '../../../rules/compatibility.js';
+
+import { expect } from 'chai';
+
+
+const BUILTINS = [
+  { name: 'from json', engines: { camunda: '>=8.9' } },
+  { name: 'to json', engines: { camunda: '>=8.9' } },
+  { name: 'get or else' }
+];
+
+function lint(expression, options = {}) {
+  return lintCompatibility({
+    expression,
+    parserDialect: 'camunda',
+    builtins: BUILTINS,
+    ...options
+  });
+}
+
+
+describe('lint - Rules - compatibility', function() {
+
+  describe('no-op', function() {
+
+    it('should not lint without engines', function() {
+
+      // given
+      const expression = 'from json("x")';
+
+      // when
+      const results = lint(expression);
+
+      // then
+      expect(results).to.have.length(0);
+    });
+
+
+    it('should not lint with empty engines', function() {
+
+      // given
+      const expression = 'from json("x")';
+
+      // when
+      const results = lint(expression, { engines: {} });
+
+      // then
+      expect(results).to.have.length(0);
+    });
+
+
+    it('should not lint without builtins', function() {
+
+      // given
+      const expression = 'from json("x")';
+
+      // when
+      const results = lint(expression, { builtins: [], engines: { camunda: '8.6' } });
+
+      // then
+      expect(results).to.have.length(0);
+    });
+
+
+    it('should not lint compatible version', function() {
+
+      // given
+      const expression = 'from json("x")';
+
+      // when
+      const results = lint(expression, { engines: { camunda: '8.9' } });
+
+      // then
+      expect(results).to.have.length(0);
+    });
+
+
+    it('should not lint builtin without engines requirement', function() {
+
+      // given
+      const expression = 'get or else(1, 2)';
+
+      // when
+      const results = lint(expression, { engines: { camunda: '8.6' } });
+
+      // then
+      expect(results).to.have.length(0);
+    });
+
+
+    it('should not lint invalid expression', function() {
+
+      // given
+      const expression = 'from json(';
+
+      // when
+      const results = lint(expression, { engines: { camunda: '8.6' } });
+
+      // then
+      expect(results).to.have.length(0);
+    });
+  });
+
+
+  describe('incompatible built-ins', function() {
+
+    it('should report incompatible built-in', function() {
+
+      // given
+      const expression = 'from json("x")';
+
+      // when
+      const results = lint(expression, { engines: { camunda: '8.6' } });
+
+      // then
+      expect(results).to.have.length(1);
+      expect(results[0]).to.include({
+        from: 0,
+        to: 9,
+        severity: 'warning',
+        type: 'compatibility',
+        message: 'Function \'from json\' requires Camunda >=8.9'
+      });
+    });
+
+
+    it('should report each invocation separately', function() {
+
+      // given
+      const expression = 'from json("x") + from json("y")';
+
+      // when
+      const results = lint(expression, { engines: { camunda: '8.6' } });
+
+      // then
+      expect(results).to.have.length(2);
+      expect(results.map(r => [ r.from, r.to ])).to.eql([ [ 0, 9 ], [ 17, 26 ] ]);
+    });
+
+
+    it('should report multiple distinct built-ins', function() {
+
+      // given
+      const expression = 'from json(to json(x))';
+
+      // when
+      const results = lint(expression, { engines: { camunda: '8.6' } });
+
+      // then
+      expect(results).to.have.length(2);
+      expect(results.map(r => r.message)).to.eql([
+        'Function \'from json\' requires Camunda >=8.9',
+        'Function \'to json\' requires Camunda >=8.9'
+      ]);
+    });
+  });
+
+
+  describe('scope awareness', function() {
+
+    it('should not report a user-defined function shadowing a built-in', function() {
+
+      // given
+      const expression = '{ from json: function(v) v, a: from json("x") }';
+
+      // when
+      const results = lint(expression, { engines: { camunda: '8.6' } });
+
+      // then
+      expect(results).to.have.length(0);
+    });
+
+
+    it('should report only the built-in invocation when a name is both', function() {
+
+      // given
+      const expression = '{ a: from json("x"), b: { from json: function(v) v, c: from json("y") } }';
+
+      // when
+      const results = lint(expression, { engines: { camunda: '8.6' } });
+
+      // then
+      expect(results).to.have.length(1);
+      expect(results[0].from).to.eql(5);
+      expect(results[0].to).to.eql(14);
+    });
+  });
+
+
+  describe('message', function() {
+
+    it('should format multiple engine requirements', function() {
+
+      // given
+      const builtins = [ { name: 'from json', engines: { camunda: '>=8.9', zeebe: '>=8.9' } } ];
+
+      // when
+      const results = lint('from json("x")', { builtins, engines: { camunda: '8.6' } });
+
+      // then
+      expect(results).to.have.length(1);
+      expect(results[0].message).to.eql('Function \'from json\' requires Camunda >=8.9, Zeebe >=8.9');
+    });
+  });
+});

--- a/test/spec/rules/compatibility.spec.js
+++ b/test/spec/rules/compatibility.spec.js
@@ -1,3 +1,6 @@
+import { parser, trackVariables } from '@bpmn-io/lezer-feel';
+
+import { createContext } from '../../../lib/text/util.js';
 import lintCompatibility from '../../../rules/compatibility.js';
 
 import { expect } from 'chai';
@@ -10,12 +13,15 @@ const BUILTINS = [
 ];
 
 function lint(expression, options = {}) {
-  return lintCompatibility({
-    expression,
-    parserDialect: 'camunda',
-    builtins: BUILTINS,
-    ...options
-  });
+  const { builtins = BUILTINS, engines } = options;
+
+  const syntaxTree = parser.configure({
+    top: 'Expression',
+    dialect: 'camunda',
+    contextTracker: trackVariables(createContext(builtins))
+  }).parse(expression);
+
+  return lintCompatibility({ syntaxTree, expression, builtins, engines });
 }
 
 

--- a/test/spec/textLinter.spec.js
+++ b/test/spec/textLinter.spec.js
@@ -116,4 +116,63 @@ describe('lint - Text', function() {
 
   });
 
+
+  describe('compatibility', function() {
+
+    const builtins = [ { name: 'from json', engines: { camunda: '>=8.9' } } ];
+
+
+    it('should warn on version-incompatible builtin', function() {
+
+      // given
+      const expression = 'from json("x")';
+
+      // when
+      const results = lintExpression(expression, {
+        parserDialect: 'camunda',
+        builtins,
+        engines: { camunda: '8.6' }
+      });
+
+      // then
+      expect(results).to.have.length(1);
+      expect(results[0].severity).to.eql('warning');
+      expect(results[0].type).to.eql('compatibility');
+      expect(results[0].message).to.eql('Function \'from json\' requires Camunda >=8.9');
+    });
+
+
+    it('should not warn when the version satisfies', function() {
+
+      // given
+      const expression = 'from json("x")';
+
+      // when
+      const results = lintExpression(expression, {
+        parserDialect: 'camunda',
+        builtins,
+        engines: { camunda: '8.9' }
+      });
+
+      // then
+      expect(results).to.have.length(0);
+    });
+
+
+    it('should not warn without engines configured', function() {
+
+      // given
+      const expression = 'from json("x")';
+
+      // when
+      const results = lintExpression(expression, {
+        parserDialect: 'camunda',
+        builtins
+      });
+
+      // then
+      expect(results).to.have.length(0);
+    });
+  });
+
 });


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5735

### Proposed Changes

Add a compatibility rule that warns on built-in function calls whose engines requirement is not satisfied by the provided engines. Opt-in via the new engines option on lintExpression and cmFeelLinter; no-op when unset.

## Try it out

1. Put [demo.js](https://github.com/user-attachments/files/29702392/demo.js) in repo root.
2. Run `npm i`
3. Run `node demo.js`.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
